### PR TITLE
Move from brainio -> imio and add dependency

### DIFF
--- a/morphapi/utils/data_io.py
+++ b/morphapi/utils/data_io.py
@@ -3,8 +3,8 @@ import json
 import requests
 import yaml
 import gzip
+import imio
 import numpy as np
-from brainio import brainio
 from vedo import load, Volume
 
 
@@ -137,7 +137,7 @@ def load_volume_file(filepath):
     if not os.path.isfile(filepath):
         raise FileNotFoundError(filepath)
     try:
-        volume = brainio.load_any(filepath)
+        volume = imio.load_any(filepath)
     except:
         raise ValueError(f"Could not load volume data: {filepath}")
     else:

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requirements = [
     "pyyaml>=5.3",
     "neurom",
     "bg_atlasapi",
+    "imio"
 ]
 
 setup(


### PR DESCRIPTION
Hi @FedeClaudi, 

Feel free to ignore it, but I thought I'd bring it to your attention.

`brainrender` tests were failing because morphapi required `brainio`, and this wasn't in the setup file. `brainio` is now deprecated in favour of `imio`, so I've updated that and added it to `setup.py`.