### PR TITLE
Fixes small api error

### DIFF
--- a/morphapi/api/neuromorphorg.py
+++ b/morphapi/api/neuromorphorg.py
@@ -80,7 +80,7 @@ class NeuroMorpOrgAPI(Paths):
                 raise NotImplementedError("Need to join the list")
 
             if n > 0:
-                url += "&"
+                url += "&fq="
             url += f"{crit}:{val}"
 
         url += f"&size={int(size)}&page={int(page)}"


### PR DESCRIPTION
Neuromorpho API filtering query should work according to http://neuromorpho.org/apiReference.html#neuron-filter-query

* This change fixes https://github.com/brainglobe/morphapi/issues/9