### PR TITLE
Rework MouseLightAPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requirements = [
     "pyyaml>=5.3",
     "neurom<4",
     "bg_atlasapi",
+    "retry",
 ]
 
 setup(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -64,6 +64,31 @@ def test_mouselight_download():
     assert neurons[0].data_file.name == "BAD ID.swc"
     assert neurons[0].points is None
 
+    # Test filter without atlas
+    filtered_neurons_metadata = mlapi.filter_neurons_metadata(
+        neurons_metadata, filterby="soma", filter_regions=["MOs6b"]
+    )
+    assert all(
+        [i["brainArea_acronym"] == "MOs6b" for i in filtered_neurons_metadata]
+    )
+
+    # Test filter with atlas
+    atlas = mlapi.fetch_default_atlas()
+
+    filtered_neurons_metadata_atlas = mlapi.filter_neurons_metadata(
+        neurons_metadata,
+        filterby="soma",
+        filter_regions=["MOs6b"],
+        atlas=atlas,
+    )
+    assert all(
+        [
+            i["brainArea_acronym"] == "MOs6b"
+            for i in filtered_neurons_metadata_atlas
+        ]
+    )
+    assert filtered_neurons_metadata == filtered_neurons_metadata_atlas
+
 
 def test_allen_morphology_download():
     am = AllenMorphology()


### PR DESCRIPTION
Extract the filtering part from the fetch_neurons_metadata() method so it
is possible to filter a list of metadata without calling the API again.
Fix the filter to keep the neurons whose soma is inside one of the given
region instead of only in their ancestors.
Add a function to fetch an atlas with a retrying feature because the atlas
server is quite unstable.
Fix cache path to actually use the MouseLightAPI cache instead of the
NeuroMorpOrgAPI cache.