### PR TITLE
Do not add current dir to sys.path and reorder imports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,5 @@
 [run]
-source = morphapi
+source =
+	morphapi
+	*/morphapi
+	*/site-packages/morphapi

--- a/examples/download/allen_morphology_api.py
+++ b/examples/download/allen_morphology_api.py
@@ -1,5 +1,6 @@
-from morphapi.api.allenmorphology import AllenMorphology
 from vedo import Plotter
+
+from morphapi.api.allenmorphology import AllenMorphology
 
 am = AllenMorphology()
 

--- a/examples/download/mouselight_api.py
+++ b/examples/download/mouselight_api.py
@@ -2,7 +2,6 @@ from vedo import Plotter
 
 from morphapi.api.mouselight import MouseLightAPI
 
-
 # ---------------------------- Downloading neurons --------------------------- #
 mlapi = MouseLightAPI()
 

--- a/examples/download/mpin_api.py
+++ b/examples/download/mpin_api.py
@@ -2,7 +2,6 @@ from vedo import Plotter
 
 from morphapi.api.mpin_celldb import MpinMorphologyAPI
 
-
 api = MpinMorphologyAPI()
 
 # ----------------------------- Download dataset ----------------------------- #

--- a/examples/download/neuromorpho_api.py
+++ b/examples/download/neuromorpho_api.py
@@ -2,7 +2,6 @@ from vedo import Plotter
 
 from morphapi.api.neuromorphorg import NeuroMorpOrgAPI
 
-
 api = NeuroMorpOrgAPI()
 
 # ---------------------------- Downloading metadata --------------------------- #

--- a/morphapi/api/allenmorphology.py
+++ b/morphapi/api/allenmorphology.py
@@ -1,11 +1,8 @@
 import logging
-import sys
-
-sys.path.append("./")
-
 import os
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 
 try:
     from allensdk.core.cell_types_cache import CellTypesCache
@@ -14,19 +11,19 @@ except ModuleNotFoundError:
         'You need to install the allen sdk package to use AllenMorphology:  "pip install allensdk"'
     )
 
+from morphapi.morphology.morphology import Neuron
 from morphapi.paths_manager import Paths
 from morphapi.utils.data_io import connected_to_internet
-from morphapi.morphology.morphology import Neuron
 
 logger = logging.getLogger(__name__)
 
 
 class AllenMorphology(Paths):
-    """ Handles the download of neuronal morphology data from the Allen database. """
+    """Handles the download of neuronal morphology data from the Allen database."""
 
     def __init__(self, *args, **kwargs):
         """
-            Initialise API interaction and fetch metadata of neurons in the Allen Database.
+        Initialise API interaction and fetch metadata of neurons in the Allen Database.
         """
         if not connected_to_internet():
             raise ConnectionError(
@@ -57,7 +54,7 @@ class AllenMorphology(Paths):
 
     def get_downloaded_neurons(self):
         """
-            Get's the path to files of downloaded neurons
+        Get's the path to files of downloaded neurons
         """
         return [
             os.path.join(self.allen_morphology_cache, f)
@@ -67,7 +64,7 @@ class AllenMorphology(Paths):
 
     def build_filepath(self, neuron_id):
         """
-            Build a filepath from neuron's metadata.
+        Build a filepath from neuron's metadata.
         """
         return os.path.join(
             self.allen_morphology_cache, "{}.swc".format(neuron_id)

--- a/morphapi/api/mouselight.py
+++ b/morphapi/api/mouselight.py
@@ -2,15 +2,16 @@ import logging
 from collections import namedtuple
 
 import pandas as pd
-
 from bg_atlasapi import BrainGlobeAtlas
 from retry import retry
 
 from morphapi.api.neuromorphorg import NeuroMorpOrgAPI
 from morphapi.morphology.morphology import Neuron
 from morphapi.paths_manager import Paths
-from morphapi.utils.data_io import is_any_item_in_list, flatten_list
-from morphapi.utils.webqueries import post_mouselight, mouselight_base_url
+from morphapi.utils.data_io import flatten_list
+from morphapi.utils.data_io import is_any_item_in_list
+from morphapi.utils.webqueries import mouselight_base_url
+from morphapi.utils.webqueries import post_mouselight
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 def mouselight_api_info():
     """
-        Get the number of cells available in the database
+    Get the number of cells available in the database
     """
     # Get info from the ML API
     url = mouselight_base_url + "graphql"
@@ -49,8 +50,8 @@ def mouselight_api_info():
 
 def mouselight_get_brainregions():
     """
-        Get metadata about the brain brain regions as they are known by Janelia's Mouse Light.
-        IDs and Names sometimes differ from Allen's CCF.
+    Get metadata about the brain brain regions as they are known by Janelia's Mouse Light.
+    IDs and Names sometimes differ from Allen's CCF.
     """
 
     # Download metadata about brain regions from the ML API
@@ -261,10 +262,10 @@ def fetch_atlas(atlas_name="allen_mouse_25um"):
 class MouseLightAPI(Paths):
     def __init__(self, base_dir=None, **kwargs):
         """
-            Handles the download of neurons morphology data from the Mouse Light project
+        Handles the download of neurons morphology data from the Mouse Light project
 
-            :param base_dir: path to directory to use for saving data (default value None)
-            :param kwargs: can be used to pass path to individual data folders. See morphapi/utils /paths_manager.py
+        :param base_dir: path to directory to use for saving data (default value None)
+        :param kwargs: can be used to pass path to individual data folders. See morphapi/utils /paths_manager.py
         """
         Paths.__init__(self, base_dir=base_dir, **kwargs)
 

--- a/morphapi/api/mpin_celldb.py
+++ b/morphapi/api/mpin_celldb.py
@@ -1,20 +1,20 @@
-import pandas as pd
-from pathlib import Path
-import zipfile
 import shutil
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+from bg_atlasapi import BrainGlobeAtlas
+from bg_atlasapi.utils import retrieve_over_http
+from bg_space import SpaceConvention
 from rich.progress import track
 
+from morphapi.morphology.morphology import Neuron
 from morphapi.paths_manager import Paths
 from morphapi.utils.data_io import connected_to_internet
-from morphapi.morphology.morphology import Neuron
-from bg_space import SpaceConvention
-from bg_atlasapi.utils import retrieve_over_http
-from bg_atlasapi import BrainGlobeAtlas
 
 
 def soma_coords_from_file(file_path):
-    """Compile dictionary with traced cells origins.
-    """
+    """Compile dictionary with traced cells origins."""
     # Read first line after comment for soma ID:
     line_start = "#"
     with open(file_path, "r") as file:
@@ -57,8 +57,7 @@ def fix_mpin_swgfile(file_path, fixed_file_path=None):
 
 
 class MpinMorphologyAPI(Paths):
-    """Handles the download of neuronal morphology data from the MPIN database.
-    """
+    """Handles the download of neuronal morphology data from the MPIN database."""
 
     def __init__(self, *args, **kwargs):
         Paths.__init__(self, *args, **kwargs)
@@ -72,8 +71,7 @@ class MpinMorphologyAPI(Paths):
 
     @property
     def neurons_df(self):
-        """Table with all neurons positions and soma regions.
-        """
+        """Table with all neurons positions and soma regions."""
         if self._neurons_df is None:
             # Generate table with soma position to query by region:
             atlas = BrainGlobeAtlas("mpin_zfish_1um", print_authors=False)
@@ -109,7 +107,7 @@ class MpinMorphologyAPI(Paths):
 
     def load_neurons(self, neuron_id, **kwargs):
         """
-            Load individual neurons given their IDs
+        Load individual neurons given their IDs
         """
         if not isinstance(neuron_id, list):
             neuron_id = [neuron_id]
@@ -122,15 +120,17 @@ class MpinMorphologyAPI(Paths):
                 / self.neurons_df.loc[nid].filename
             )
             to_return.append(
-                Neuron(filepath, neuron_name="mpin_" + str(nid), **kwargs,)
+                Neuron(
+                    filepath,
+                    neuron_name="mpin_" + str(nid),
+                    **kwargs,
+                )
             )
 
         return to_return
 
     def download_dataset(self):
-        """Dowload dataset from Kunst et al 2019.
-
-        """
+        """Dowload dataset from Kunst et al 2019."""
         if not connected_to_internet():
             raise ValueError(
                 "An internet connection is required to download the dataset"

--- a/morphapi/api/neuromorphorg.py
+++ b/morphapi/api/neuromorphorg.py
@@ -2,9 +2,10 @@ import logging
 import os
 from functools import partial
 
-from morphapi.utils.webqueries import request, connected_to_internet
-from morphapi.paths_manager import Paths
 from morphapi.morphology.morphology import Neuron
+from morphapi.paths_manager import Paths
+from morphapi.utils.webqueries import connected_to_internet
+from morphapi.utils.webqueries import request
 
 logger = logging.getLogger(__name__)
 request_no_ssl = partial(request, verify=False)

--- a/morphapi/morphology/cache.py
+++ b/morphapi/morphology/cache.py
@@ -1,9 +1,13 @@
 import os
 
-from vedo import write, load, Mesh, merge
+from vedo import Mesh
+from vedo import load
+from vedo import merge
+from vedo import write
 
 from morphapi.paths_manager import Paths
-from morphapi.utils.data_io import save_yaml, load_yaml
+from morphapi.utils.data_io import load_yaml
+from morphapi.utils.data_io import save_yaml
 
 
 class NeuronCache(Paths):
@@ -17,7 +21,7 @@ class NeuronCache(Paths):
 
     def __init__(self, **kwargs):
         """
-            Initialise API interaction and fetch metadata of neurons in the Allen Database. 
+        Initialise API interaction and fetch metadata of neurons in the Allen Database.
         """
         super().__init__(**kwargs)  # path to data caches
 

--- a/morphapi/morphology/morphology.py
+++ b/morphapi/morphology/morphology.py
@@ -1,13 +1,13 @@
 import logging
-from pathlib import Path
 from collections import namedtuple
-
-from vedo.shapes import Sphere, Tube
-from vedo import merge
-from vedo.colors import colorMap
+from pathlib import Path
 
 import neurom as nm
 from neurom.core.dataformat import COLS
+from vedo import merge
+from vedo.colors import colorMap
+from vedo.shapes import Sphere
+from vedo.shapes import Tube
 
 try:
     # For NeuroM >= 3
@@ -20,10 +20,9 @@ except ImportError:
         # For NeuroM >= 2, < 3
         from neurom import iter_sections
 
+import warnings
 
 from morphapi.morphology.cache import NeuronCache
-
-import warnings
 
 warnings.filterwarnings("ignore")
 

--- a/morphapi/paths_manager.py
+++ b/morphapi/paths_manager.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 """
@@ -15,17 +14,16 @@ default_paths = dict(
     meshes_cache="Data/meshes_cache",
     # Other
     mouse_connectivity_cache="Data/mouse_connectivity_cache",
-    mpin_morphology="Data/mpin_morphology"
+    mpin_morphology="Data/mpin_morphology",
 )
 
 
 class Paths:
-
     def __init__(self, base_dir=None, **kwargs):
         """
-        Parses a YAML file to get data folders paths. Stores paths to a number of folders used throughtout morphapi. 
-        
-        :param base_dir: str with path to directory to use to save data. If none the user's base directiry is used. 
+        Parses a YAML file to get data folders paths. Stores paths to a number of folders used throughtout morphapi.
+
+        :param base_dir: str with path to directory to use to save data. If none the user's base directiry is used.
         :param kwargs: use the name of a folder as key and a path as argument to specify the path of individual subfolders
         """
         # Get and make base directory
@@ -40,8 +38,7 @@ class Paths:
         for fld_name, folder in default_paths.items():
             # Check if user provided a path for this folder, otherwise use default
 
-            path = self.base_dir / kwargs.pop(fld_name,
-                                              folder)
+            path = self.base_dir / kwargs.pop(fld_name, folder)
 
             # Create folder if it doesn't exist:
             path.mkdir(parents=True, exist_ok=True)

--- a/morphapi/utils/data_io.py
+++ b/morphapi/utils/data_io.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 import yaml
 
@@ -65,10 +66,10 @@ def load_yaml(filepath):
 # ----------------------------- Internet queries ----------------------------- #
 def connected_to_internet(url="http://www.google.com/", timeout=5):
     """
-        Check that there is an internet connection
+    Check that there is an internet connection
 
-        :param url: url to use for testing (Default value = 'http://www.google.com/')
-        :param timeout:  timeout to wait for [in seconds] (Default value = 5)
+    :param url: url to use for testing (Default value = 'http://www.google.com/')
+    :param timeout:  timeout to wait for [in seconds] (Default value = 5)
     """
 
     try:
@@ -85,7 +86,7 @@ def connected_to_internet(url="http://www.google.com/", timeout=5):
 def flatten_list(lst):
     """
     Flattens a list of lists
-    
+
     :param lst: list
 
     """
@@ -102,8 +103,8 @@ def is_any_item_in_list(L1, L2):
     """
     Checks if an item in a list is in another  list
 
-    :param L1: 
-    :param L2: 
+    :param L1:
+    :param L2:
 
     """
     # checks if any item of L1 is also in L2 and returns false otherwise

--- a/morphapi/utils/webqueries.py
+++ b/morphapi/utils/webqueries.py
@@ -1,12 +1,8 @@
-import sys
-
-sys.path.append("./")
-
-from morphapi.utils.data_io import connected_to_internet
-
-import requests
 import time
 
+import requests
+
+from morphapi.utils.data_io import connected_to_internet
 
 mouselight_base_url = "http://ml-neuronbrowser.janelia.org/"
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-from setuptools import setup, find_namespace_packages
 from os import path
+
+from setuptools import find_namespace_packages
+from setuptools import setup
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,9 +1,6 @@
-import sys
-
-sys.path.append("./")
+from morphapi.api.allenmorphology import AllenMorphology
 from morphapi.api.mouselight import MouseLightAPI
 from morphapi.api.neuromorphorg import NeuroMorpOrgAPI
-from morphapi.api.allenmorphology import AllenMorphology
 
 
 def test_neuromorpho_download():

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -1,13 +1,11 @@
-import sys
-
-sys.path.append("./")
-
-import pytest
-import numpy as np
 from random import choice
+
+import numpy as np
+import pytest
+from vedo import Mesh
+
 from morphapi.morphology.morphology import Neuron
 from morphapi.utils.data_io import listdir
-from vedo import Mesh
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps:
     py39: numpy  # This is required during installation
 commands = pytest \
     --basetemp={envtmpdir} \
+    --cov=morphapi \
     --cov-report term-missing \
     --cov-report html:reports/coverage-{envname} \
     --cov-report xml:reports/coverage-{envname}.xml \


### PR DESCRIPTION
I saw that the current working directory is added to `sys.path`, which might lead to weird behaviors and should not be needed (do you remember why you did this?). So I suggest removing it.

I also run isort and black to improve formatting.