### PR TITLE
NeuroMorpho: Can use neuron names as file names

### DIFF
--- a/morphapi/api/mouselight.py
+++ b/morphapi/api/mouselight.py
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 """
-    Collections of functions to query http://ml-neuronbrowser.janelia.org/ and get data about either the status of the API,
+    Collections of functions to query https://ml-neuronbrowser.janelia.org/ and get data about either the status of the API,
     the brain regions or the neurons available.
-    Queries are sent by sending POST requests to http://ml-neuronbrowser.janelia.org/graphql
+    Queries are sent by sending POST requests to https://ml-neuronbrowser.janelia.org/graphql
     with a string query.
 """
 

--- a/morphapi/api/neuromorphorg.py
+++ b/morphapi/api/neuromorphorg.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import urllib
 from functools import partial
 
 from morphapi.morphology.morphology import Neuron
@@ -90,7 +91,7 @@ class NeuroMorpOrgAPI(Paths):
 
             if n > 0:
                 url += "&fq="
-            url += f"{crit}:{val}"
+            url += f"{crit}:" + urllib.parse.quote(f"{val}")
 
         url += f"&size={int(size)}&page={int(page)}"
         req = request_no_ssl(url)
@@ -129,16 +130,25 @@ class NeuroMorpOrgAPI(Paths):
         return os.path.join(self.neuromorphorg_cache, f"{neuron_id}.swc")
 
     def download_neurons(
-        self, neurons, _name=None, load_neurons=True, **kwargs
+        self,
+        neurons,
+        _name=None,
+        load_neurons=True,
+        use_neuron_names=False,
+        **kwargs,
     ):
         """
         Downloads neuronal morphological data and saves it to .swc files.
         It then returns a list of Neuron instances with morphological data for each neuron.
 
         :param neurons: list of neurons metadata (as returned by one of the functions
-                    used to fetch metadata)
+            used to fetch metadata)
         :param _name: used internally to save cached neurons with a different prefix when the
-                class is used to download neurons for other APIs
+            class is used to download neurons for other APIs
+        :param load_neurons: if set to True, the neurons are loaded into a
+            `morphapi.morphology.morphology.Neuron` object and returned
+        :param use_neuron_names: if set to True, the filenames use the names of the neurons instead
+            of their IDs
         """
         if not isinstance(neurons, (list, tuple)):
             neurons = [neurons]
@@ -154,7 +164,12 @@ class NeuroMorpOrgAPI(Paths):
             except KeyError:
                 pass
 
-            filepath = self.build_filepath(neuron["neuron_id"])
+            if use_neuron_names:
+                filepath = self.build_filepath(
+                    neuron.get("neuron_name", neuron["neuron_id"])
+                )
+            else:
+                filepath = self.build_filepath(neuron["neuron_id"])
             load_current_neuron = load_neurons
 
             if not os.path.isfile(filepath):

--- a/morphapi/api/neuromorphorg.py
+++ b/morphapi/api/neuromorphorg.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import urllib
 from functools import partial
 
 from morphapi.morphology.morphology import Neuron
@@ -91,7 +90,7 @@ class NeuroMorpOrgAPI(Paths):
 
             if n > 0:
                 url += "&fq="
-            url += f"{crit}:" + urllib.parse.quote(f"{val}")
+            url += f"{crit}:{val}"
 
         url += f"&size={int(size)}&page={int(page)}"
         req = request_no_ssl(url)

--- a/morphapi/paths_manager.py
+++ b/morphapi/paths_manager.py
@@ -31,7 +31,7 @@ class Paths:
         if base_dir is None:
             self.base_dir = Path.home() / ".morphapi"
         else:
-            self.base_dir = base_dir
+            self.base_dir = Path(base_dir)
 
         self.base_dir.mkdir(exist_ok=True)
 


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

When downloading neurons from NeuroMorpho we lose the neuron names, which can be interesting in some cases. 

**What does this PR do?**

With this PR we can keep these names as files names.

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

I improved a test to consider this change.

## Is this a breaking change?

No, the default behavior is kept unchanged.

## Does this PR require an update to the documentation?

I improved the related docstring.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
