### PR TITLE
Fix: Compatibility with urllib3>=2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requirements = [
     "pyyaml>=5.3",
     "retry",
     "rich",
+    "urllib3<2",
     "vedo>=2021.0.3",
     "vtk",
 ]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ requirements = [
     "pyyaml>=5.3",
     "retry",
     "rich",
-    "urllib3<2",
     "vedo>=2021.0.3",
     "vtk",
 ]


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
`urllib3` removed `DEFAULT_CIPHERS` from `urllib3.util.ssl_`

**What does this PR do?**
Create a context with specific ciphers.


## How has this PR been tested?

The tests fail on the master branch and pass on this branch.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
