### PR TITLE
Compatibility with vedo 2023.5.0

### DIFF
--- a/morphapi/morphology/morphology.py
+++ b/morphapi/morphology/morphology.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import neurom as nm
 from neurom.core.dataformat import COLS
 from vedo import merge
-from vedo.colors import colorMap
+from vedo.colors import color_map
 from vedo.shapes import Sphere
 from vedo.shapes import Tube
 
@@ -172,7 +172,7 @@ class Neuron(NeuronCache):
             if neuron_number is None:
                 neuron_number = 0
 
-            soma_color = colorMap(
+            soma_color = color_map(
                 neuron_number, name=cmap, vmin=cmap_lims[0], vmax=cmap_lims[1]
             )
             apical_dendrites_color = (

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     "pyyaml>=5.3",
     "retry",
     "rich",
-    "vedo>=2021.0.3",
+    "vedo>=2023.5.0",
     "vtk",
 ]
 


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**
Makes the code compatible with vedo 2023.5.0.

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
vedo 2023.5.0 released yesterday.

**What does this PR do?**
Changes an import statement and pins vedo>=2023.5.0 as this is a breaking change.

## References
closes #42 

## How has this PR been tested?

Code has been tested locally.

## Is this a breaking change?

Yes, users will have to update to vedo 2023.5.0 since `vedo.colors.py::colorMap` is now `vedo.colors.py::color_map`

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
