### PR TITLE
bg-atlasapi to brainglobe-atlasapi

### DIFF
--- a/morphapi/api/mouselight.py
+++ b/morphapi/api/mouselight.py
@@ -10,7 +10,7 @@ import logging
 from collections import namedtuple
 
 import pandas as pd
-from bg_atlasapi import BrainGlobeAtlas
+from brainglobe_atlasapi import BrainGlobeAtlas
 from retry import retry
 
 from morphapi.api.neuromorphorg import NeuroMorpOrgAPI
@@ -254,7 +254,7 @@ def fetch_atlas(atlas_name="allen_mouse_25um"):
     """Fetch a given atlas.
 
     See here for available atlases:
-    https://docs.brainglobe.info/bg-atlasapi/introduction#atlases-available
+    https://docs.brainglobe.info/brainglobe-atlasapi/introduction#atlases-available
     """
     return BrainGlobeAtlas(atlas_name)
 
@@ -408,7 +408,7 @@ class MouseLightAPI(Paths):
         :param filter_regions: List of brain regions acronyms.
         If filtering neurons, these specify
         the filter criteria. (Default value = None)
-        :param atlas: A `bg_atlasapi.BrainGlobeAtlas` object.
+        :param atlas: A `brainglobe_atlasapi.BrainGlobeAtlas` object.
         If not provided, load the default atlas.
         """
 

--- a/morphapi/api/mpin_celldb.py
+++ b/morphapi/api/mpin_celldb.py
@@ -3,8 +3,8 @@ import zipfile
 from pathlib import Path
 
 import pandas as pd
-from bg_atlasapi import BrainGlobeAtlas
-from bg_atlasapi.utils import retrieve_over_http
+from brainglobe_atlasapi import BrainGlobeAtlas
+from brainglobe_atlasapi.utils import retrieve_over_http
 from brainglobe_space import SpaceConvention
 from rich.progress import track
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.9.0"
 dynamic = ["version"]
 
 dependencies = [
-    "bg_atlasapi",
+    "brainglobe-atlasapi >=2.0.1",
     "brainglobe-space >=1.0.0",
     "imagecodecs; python_version>='3.9'",
     "neurom>=3,<4",
@@ -90,8 +90,10 @@ ignore = [
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py", "build", ".eggs"]
-select = ["I", "E", "F"]
 fix = true
+
+[tool.ruff.lint]
+select = ["I", "E", "F"]
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
As per https://github.com/brainglobe/BrainGlobe/issues/43

Requesting a review since this PR should be good to go, as it's just a rename for a dependency. Tests fail due to the site that the code is trying to reach being down.