### PR TITLE
Migrate away from allensdk

### DIFF
--- a/morphapi/api/allenmorphology.py
+++ b/morphapi/api/allenmorphology.py
@@ -1,22 +1,36 @@
+import json
 import logging
 import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
-
-try:
-    from allensdk.core.cell_types_cache import CellTypesCache
-except ModuleNotFoundError:
-    raise ModuleNotFoundError(
-        "You need to install the allen sdk package to use "
-        'AllenMorphology:  "pip install allensdk"'
-    )
+import requests
 
 from morphapi.morphology.morphology import Neuron
 from morphapi.paths_manager import Paths
 from morphapi.utils.data_io import connected_to_internet
 
 logger = logging.getLogger(__name__)
+
+columns_of_interest = {
+    "cell_reporter_status": "reporter_status",
+    "cell_soma_location": "cell_soma_location",
+    "donor__species": "species",
+    "specimen__id": "id",
+    "specimen__name": "name",
+    "structure__layer": "structure_layer_name",
+    "structure__id": "structure_area_id",
+    "structure_parent__acronym": "structure_area_abbrev",
+    "line_name": "transgenic_line",
+    "tag__dendrite_type": "dendrite_type",
+    "tag__apical": "apical",
+    "nr__reconstruction_type": "reconstruction_type",
+    "donor__disease_state": "disease_state",
+    "donor__id": "donor_id",
+    "specimen__hemisphere": "structure_hemisphere",
+    "csl__normalized_depth": "normalized_depth",
+}
 
 
 class AllenMorphology(Paths):
@@ -36,18 +50,9 @@ class AllenMorphology(Paths):
 
         Paths.__init__(self, *args, **kwargs)
 
-        # Create a Cache for the Cell Types Cache API
-        self.ctc = CellTypesCache(
-            manifest_file=os.path.join(
-                self.allen_morphology_cache, "manifest.json"
-            )
-        )
-
         # Get a list of cell metadata for neurons with reconstructions,
         # download if necessary
-        self.neurons = pd.DataFrame(
-            self.ctc.get_cells(require_reconstruction=True)
-        )
+        self.neurons = self.get_cells(require_reconstruction=True)
         self.n_neurons = len(self.neurons)
 
         if not self.n_neurons:
@@ -58,9 +63,88 @@ class AllenMorphology(Paths):
 
         self.downloaded_neurons = self.get_downloaded_neurons()
 
+    def get_cells(self, require_reconstruction: bool = True) -> pd.DataFrame:
+        """
+        Download the metadata for all neurons in the Allen database and save
+        it to a cells_api.json file.
+        """
+        cells_path = Path(
+            os.path.join(self.allen_morphology_cache, "cells.json")
+        )
+
+        if not cells_path.exists():
+            cells = self.fetch_all_cell_metadata(cells_path)
+        else:
+            cells = self.check_cell_metadata(cells_path)
+
+        cells["cell_soma_location"] = cells[
+            ["csl__x", "csl__y", "csl__z"]
+        ].apply(list, axis=1)
+        cells = cells[columns_of_interest.keys()].rename(
+            columns=columns_of_interest
+        )
+
+        if require_reconstruction:
+            cells.dropna(subset=["reconstruction_type"], inplace=True)
+            cells.reset_index(inplace=True, drop=True)
+
+        return cells
+
+    def fetch_all_cell_metadata(self, cells_path) -> pd.DataFrame:
+        """
+        Fetches the metadata for all neurons in the Allen database and saves
+        it to a json file.
+
+        :param cells_path: Path to save the metadata to
+        """
+        query = "http://api.brain-map.org/api/v2/data/query.json?criteria=model::ApiCellTypesSpecimenDetail,rma::options[num_rows$eqall]"
+
+        try:
+            r = requests.get(query)
+            with open(cells_path, "w") as f:
+                json.dump(r.json()["msg"], f, indent=4)
+        except requests.exceptions.RequestException as e:
+            logger.error(
+                "Could not fetch the neuron metadata for the following "
+                "reason: %s",
+                str(e),
+            )
+            raise e
+
+        return pd.read_json(cells_path)
+
+    def check_cell_metadata(self, cells_path) -> pd.DataFrame:
+        """
+        Check if the metadata file is up-to-date and return the metadata
+        as a pandas DataFrame.
+
+        :param cells_path: Path to the metadata file
+        """
+        # Query for all cell types but return no rows (check for total number)
+        query = "http://api.brain-map.org/api/v2/data/query.json?criteria=model::ApiCellTypesSpecimenDetail,rma::options[num_rows$eq0]"
+
+        cells = pd.read_json(cells_path)
+        try:
+            r = requests.get(query)
+        except requests.exceptions.RequestException as e:
+            logger.error(
+                "Could not check for metadata validity for the following "
+                "reason: %s",
+                str(e),
+            )
+            return cells
+
+        n_cells = r.json()["total_rows"]
+
+        if n_cells != len(cells):
+            logger.info("Updating neuron metadata")
+            cells = self.fetch_all_cell_metadata(cells_path)
+
+        return cells
+
     def get_downloaded_neurons(self):
         """
-        Get's the path to files of downloaded neurons
+        Gets the path to files of downloaded neurons
         """
         return [
             os.path.join(self.allen_morphology_cache, f)
@@ -99,7 +183,7 @@ class AllenMorphology(Paths):
 
             # Download file
             try:
-                self.ctc.get_reconstruction(neuron_id, file_name=neuron_file)
+                self.get_reconstruction(neuron_id, file_name=neuron_file)
             except Exception as exc:
                 logger.error(
                     "Could not fetch the neuron %s "
@@ -120,3 +204,30 @@ class AllenMorphology(Paths):
             )
 
         return neurons
+
+    def get_reconstruction(self, neuron_id: int, file_name: str):
+        """
+        Download a neuron's reconstruction from the Allen database.
+
+        :param neuron_id: int, neuron ID
+        :param file_name: str, path to save the neuron's reconstruction to
+        """
+        query_for_file_path = f"http://api.brain-map.org/api/v2/data/query.json?criteria=model::NeuronReconstruction,rma::criteria,[specimen_id$eq{neuron_id}],rma::include,well_known_files"
+
+        r = requests.get(query_for_file_path)
+        file_paths = r.json()["msg"][0]["well_known_files"]
+        file_path = None
+        for file in file_paths:
+            if ".png" not in file["path"] and "marker" not in file["path"]:
+                file_path = file["download_link"]
+                break
+
+        if not file_path:
+            raise ValueError(
+                f"Could not find a reconstruction file for neuron {neuron_id}"
+            )
+
+        query_file = f"http://api.brain-map.org{file_path}"
+        r = requests.get(query_file)
+        with open(file_name, "wb") as f:
+            f.write(r.content)

--- a/morphapi/api/allenmorphology.py
+++ b/morphapi/api/allenmorphology.py
@@ -66,7 +66,7 @@ class AllenMorphology(Paths):
     def get_cells(self, require_reconstruction: bool = True) -> pd.DataFrame:
         """
         Download the metadata for all neurons in the Allen database and save
-        it to a cells_api.json file.
+        it to a cells.json file.
         """
         cells_path = Path(
             os.path.join(self.allen_morphology_cache, "cells.json")
@@ -162,11 +162,10 @@ class AllenMorphology(Paths):
 
     def download_neurons(self, ids, load_neurons=True, **kwargs):
         """
-            Download neurons and return neuron reconstructions (instances
-            of Neuron class)
+        Download neurons and return neuron reconstructions (instances
+        of Neuron class)
 
         :param ids: list of integers with neurons IDs
-
         """
         if isinstance(ids, np.ndarray):
             ids = ids.tolist()

--- a/morphapi/api/allenmorphology.py
+++ b/morphapi/api/allenmorphology.py
@@ -217,10 +217,13 @@ class AllenMorphology(Paths):
         file_paths = r.json()["msg"][0]["well_known_files"]
         file_path = None
         for file in file_paths:
+            # There are 3 types of files for each reconstructed neuron:
+            # .png, .swc and marker_m.swc files. We want the plain .swc file
             if ".png" not in file["path"] and "marker" not in file["path"]:
                 file_path = file["download_link"]
                 break
 
+        # Check to make sure a path to a reconstruction swc file was found
         if not file_path:
             raise ValueError(
                 f"Could not find a reconstruction file for neuron {neuron_id}"

--- a/morphapi/api/allenmorphology.py
+++ b/morphapi/api/allenmorphology.py
@@ -97,7 +97,7 @@ class AllenMorphology(Paths):
 
         :param cells_path: Path to save the metadata to
         """
-        query = "http://api.brain-map.org/api/v2/data/query.json?criteria=model::ApiCellTypesSpecimenDetail,rma::options[num_rows$eqall]"
+        query = "https://api.brain-map.org/api/v2/data/query.json?criteria=model::ApiCellTypesSpecimenDetail,rma::options[num_rows$eqall]"
 
         try:
             r = requests.get(query)
@@ -121,7 +121,7 @@ class AllenMorphology(Paths):
         :param cells_path: Path to the metadata file
         """
         # Query for all cell types but return no rows (check for total number)
-        query = "http://api.brain-map.org/api/v2/data/query.json?criteria=model::ApiCellTypesSpecimenDetail,rma::options[num_rows$eq0]"
+        query = "https://api.brain-map.org/api/v2/data/query.json?criteria=model::ApiCellTypesSpecimenDetail,rma::options[num_rows$eq0]"
 
         cells = pd.read_json(cells_path)
         try:
@@ -211,7 +211,7 @@ class AllenMorphology(Paths):
         :param neuron_id: int, neuron ID
         :param file_name: str, path to save the neuron's reconstruction to
         """
-        query_for_file_path = f"http://api.brain-map.org/api/v2/data/query.json?criteria=model::NeuronReconstruction,rma::criteria,[specimen_id$eq{neuron_id}],rma::include,well_known_files"
+        query_for_file_path = f"https://api.brain-map.org/api/v2/data/query.json?criteria=model::NeuronReconstruction,rma::criteria,[specimen_id$eq{neuron_id}],rma::include,well_known_files"
 
         r = requests.get(query_for_file_path)
         file_paths = r.json()["msg"][0]["well_known_files"]
@@ -229,7 +229,7 @@ class AllenMorphology(Paths):
                 f"Could not find a reconstruction file for neuron {neuron_id}"
             )
 
-        query_file = f"http://api.brain-map.org{file_path}"
+        query_file = f"https://api.brain-map.org{file_path}"
         r = requests.get(query_file)
         with open(file_name, "wb") as f:
             f.write(r.content)

--- a/morphapi/api/allenmorphology.py
+++ b/morphapi/api/allenmorphology.py
@@ -69,7 +69,7 @@ class AllenMorphology(Paths):
         it to a cells.json file.
         """
         cells_path = Path(
-            os.path.join(self.allen_morphology_cache, "cells.json")
+            os.path.join(self.allen_morphology_cache, "cells.json")  # type: ignore[attr-defined]
         )
 
         if not cells_path.exists():
@@ -147,8 +147,8 @@ class AllenMorphology(Paths):
         Gets the path to files of downloaded neurons
         """
         return [
-            os.path.join(self.allen_morphology_cache, f)
-            for f in os.listdir(self.allen_morphology_cache)
+            os.path.join(self.allen_morphology_cache, f)  # type: ignore[attr-defined]
+            for f in os.listdir(self.allen_morphology_cache)  # type: ignore[attr-defined]
             if ".swc" in f
         ]
 
@@ -157,7 +157,7 @@ class AllenMorphology(Paths):
         Build a filepath from neuron's metadata.
         """
         return os.path.join(
-            self.allen_morphology_cache, "{}.swc".format(neuron_id)
+            self.allen_morphology_cache, "{}.swc".format(neuron_id)  # type: ignore[attr-defined]
         )
 
     def download_neurons(self, ids, load_neurons=True, **kwargs):

--- a/morphapi/api/allenmorphology.py
+++ b/morphapi/api/allenmorphology.py
@@ -68,9 +68,7 @@ class AllenMorphology(Paths):
         Download the metadata for all neurons in the Allen database and save
         it to a cells.json file.
         """
-        cells_path = Path(
-            os.path.join(self.allen_morphology_cache, "cells.json")  # type: ignore[attr-defined]
-        )
+        cells_path = Path(self.allen_morphology_cache) / "cells.json"  # type: ignore[attr-defined]
 
         if not cells_path.exists():
             cells = self.fetch_all_cell_metadata(cells_path)

--- a/morphapi/morphology/cache.py
+++ b/morphapi/morphology/cache.py
@@ -72,7 +72,7 @@ class NeuronCache(Paths):
         }
 
         for nn, act in loaded.items():
-            if len(act.points()) == 0:
+            if len(act.vertices) == 0:
                 loaded[nn] = None
 
         return loaded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dev = [
     "ruff",
     "setuptools_scm",
     "pytest-sugar",
-    "allensdk",
 ]
 
 nb = ["jupyter", "k3d"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pyyaml>=5.3",
+    "requests",
     "retry",
     "rich",
     "vedo>=2023.5.0",


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
We want to remove allensdk as a dependency to make upgrading to python 3.12 easy, see [here](https://github.com/AllenInstitute/AllenSDK/issues/2744)

**What does this PR do?**
Uses the Allen web API to fetch the reconstructed neurons instead of using the allensdk.

## References
Closes #67 

## How has this PR been tested?
All tests pass, I've also tested it locally to make sure we can fetch a variety of files.

## Is this a breaking change?
No, I made sure that the DataFrame stored in the `neurons` attribute of `AllenMorphology` class has the exact same format.

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
