### PR TITLE
Add a fallback URL for NeuroMorpho API health check

### DIFF
--- a/morphapi/api/neuromorphorg.py
+++ b/morphapi/api/neuromorphorg.py
@@ -32,7 +32,7 @@ class NeuroMorpOrgAPI(Paths):
             request(health_url, verify=False)
         except (requests.exceptions.RequestException, ValueError):
             try:
-                self._base_url = "https://neuromorpho.org/api/neuron"
+                self._base_url = "http://neuromorpho.org/api/neuron"
                 health_url = (
                     "/".join(self._base_url.split("/")[:-1]) + "/health"
                 )

--- a/morphapi/api/neuromorphorg.py
+++ b/morphapi/api/neuromorphorg.py
@@ -28,11 +28,22 @@ class NeuroMorpOrgAPI(Paths):
 
         # Check that neuromorpho.org is not down
         try:
-            request("http://cng.gmu.edu:8080/api/health", verify=False)
-        except requests.exceptions.RequestException as e:
-            raise ConnectionError(
-                f"It seems that neuromorpho API is down: {e}"
-            )
+            health_url = "/".join(self._base_url.split("/")[:-1]) + "/health"
+            request(health_url, verify=False)
+        except (requests.exceptions.RequestException, ValueError):
+            try:
+                self._base_url = "https://neuromorpho.org/api/neuron"
+                health_url = (
+                    "/".join(self._base_url.split("/")[:-1]) + "/health"
+                )
+                request(health_url, verify=False)
+            except (
+                requests.exceptions.RequestException,
+                ValueError,
+            ) as e:
+                raise ConnectionError(
+                    f"It seems that neuromorpho API is down: {e}"
+                )
 
         self._fields = None
 


### PR DESCRIPTION
Currently, http://cng.gmu.edu:8080/api/health returns a 503 when queried. Interestingly, if you query the API regardless it returns valid output e.g. http://cng.gmu.edu:8080/api/neuron/id/1.

This PR adds a fallback URL for querying API health if http://cng.gmu.edu:8080/api/health doesn't return 200. In this case `self._base_url` is swapped for http://neuromorpho.org/api/neuron instead of http://cng.gmu.edu:8080/api/neuron.